### PR TITLE
toolset props change to fix msvs always out of date bug with clang-cl.

### DIFF
--- a/assets/clang-cl/Toolset.props
+++ b/assets/clang-cl/Toolset.props
@@ -11,6 +11,10 @@
 
   <ItemDefinitionGroup>
     <ClCompile>
+      <!-- clang-cl embeds debug data in obj files. does not generate pdb per lib. if not cleared projects will always appear out of date to MSVS. -->
+      <ProgramDataBaseFileName/>
+      <!-- /Gm- /Gm option not recognized or used by clang-cl, causing an annoying warning. -->
+      <MinimalRebuild/>
       <AdditionalOptions Condition="'$(Platform)'=='Win32'">-m32 -fmsc-version=1910 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalOptions Condition="'$(Platform)'=='x64'">-m64 -fmsc-version=1910 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>


### PR DESCRIPTION
When building projects using the clang-cl toolset integration visual studio always thinks the projects are out of date. 
This is due to clang-cl not generating intermediate pdb files. It silently ignores the command line option specifying the name of intermediate pdb files and puts debug data in the .obj files.

adding a tag to the toolset props compile section to clear that command line argument keeps MSVS from looking for the file and assuming project is out of date.

additional change eliminates an annoying ignored command line argument warning.